### PR TITLE
Add get event listeners methods

### DIFF
--- a/bindings/Main.cpp
+++ b/bindings/Main.cpp
@@ -310,12 +310,12 @@ static void GetEventListeners(const v8::FunctionCallbackInfo<v8::Value>& info)
 
 	if(info[0]->IsNull())
 	{
-		handlers = resource->GetGenericHandlers(true);
+		handlers = std::move(resource->GetGenericHandlers(true));
 	}
 	else
 	{
 		V8_ARG_TO_STRING(1, eventName);
-		handlers = resource->GetLocalHandlers(eventName.ToString());
+		handlers = std::move(resource->GetLocalHandlers(eventName.ToString()));
 	}
 
 	auto array = v8::Array::New(isolate, handlers.size());
@@ -336,12 +336,12 @@ static void GetRemoteEventListeners(const v8::FunctionCallbackInfo<v8::Value>& i
 
 	if(info[0]->IsNull())
 	{
-		handlers = resource->GetGenericHandlers(false);
+		handlers = std::move(resource->GetGenericHandlers(false));
 	}
 	else
 	{
 		V8_ARG_TO_STRING(1, eventName);
-		handlers = resource->GetRemoteHandlers(eventName.ToString());
+		handlers = std::move(resource->GetRemoteHandlers(eventName.ToString()));
 	}
 
 	auto array = v8::Array::New(isolate, handlers.size());


### PR DESCRIPTION
Adds methods to get the current registered event handlers.
Typings:
```ts
export function getEventListeners(eventName: string | null): Function[];
export function getRemoteEventListeners(eventName: string | null): Function[];
```
When `null` is passed as the event name, it gets the generic event handlers.

See https://github.com/altmp/v8-helpers/issues/26