### PR TITLE
Stricter SafeTo* helpers type checks

### DIFF
--- a/V8Helpers.cpp
+++ b/V8Helpers.cpp
@@ -528,92 +528,72 @@ v8::Local<v8::String> V8::Fire_WeaponKey(v8::Isolate* isolate)
 
 bool V8::SafeToBoolean(v8::Local<v8::Value> val, v8::Isolate* isolate, bool& out)
 {
+	if(!val->IsBoolean()) return false;
 	out = val->ToBoolean(isolate)->Value();
 	return true;
 }
 
 bool V8::SafeToInteger(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, int64_t& out)
 {
+	if(!val->IsNumber()) return false;
 	v8::MaybeLocal maybeVal = val->ToInteger(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = maybeVal.ToLocalChecked()->Value();
-		return true;
-	}
-
-	return false;
+	if(maybeVal.IsEmpty()) return false;
+	out = maybeVal.ToLocalChecked()->Value();
+	return true;
 }
 
 bool V8::SafeToUInt64(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, uint64_t& out)
 {
+	if(!val->IsNumber()) return false;
 	v8::MaybeLocal maybeVal = val->ToBigInt(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = maybeVal.ToLocalChecked()->Uint64Value();
-		return true;
-	}
-
-	return false;
+	if(maybeVal.IsEmpty()) return false;
+	out = maybeVal.ToLocalChecked()->Uint64Value();
+	return true;
 }
 
 bool V8::SafeToInt64(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, int64_t& out)
 {
+	if(!val->IsNumber()) return false;
 	v8::MaybeLocal maybeVal = val->ToBigInt(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = maybeVal.ToLocalChecked()->Int64Value();
-		return true;
-	}
-
-	return false;
+	if(maybeVal.IsEmpty()) return false;
+	out = maybeVal.ToLocalChecked()->Int64Value();
+	return true;
 }
 
 bool V8::SafeToUInt32(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, uint32_t& out)
 {
+	if(!val->IsNumber()) return false;
 	v8::MaybeLocal maybeVal = val->ToUint32(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = maybeVal.ToLocalChecked()->Value();
-		return true;
-	}
-
-	return false;
+	if(maybeVal.IsEmpty()) return false;
+	out = maybeVal.ToLocalChecked()->Value();
+	return true;
 }
 
 bool V8::SafeToInt32(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, int32_t& out)
 {
+	if(!val->IsNumber()) return false;
 	v8::MaybeLocal maybeVal = val->ToInt32(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = maybeVal.ToLocalChecked()->Value();
-		return true;
-	}
-
-	return false;
+	if(maybeVal.IsEmpty()) return false;
+	out = maybeVal.ToLocalChecked()->Value();
+	return true;
 }
 
 bool V8::SafeToNumber(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, double& out)
 {
+	if(!val->IsNumber()) return false;
 	v8::MaybeLocal maybeVal = val->ToNumber(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = maybeVal.ToLocalChecked()->Value();
-		return true;
-	}
-
-	return false;
+	if(maybeVal.IsEmpty()) return false;
+	out = maybeVal.ToLocalChecked()->Value();
+	return true;
 }
 
 bool V8::SafeToString(v8::Local<v8::Value> val, v8::Isolate* isolate, v8::Local<v8::Context> ctx, alt::String& out)
 {
+	if(!val->IsString()) return false;
 	v8::MaybeLocal maybeVal = val->ToString(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = *v8::String::Utf8Value(isolate, maybeVal.ToLocalChecked());
-		return true;
-	}
-
-	return false;
+	if(maybeVal.IsEmpty()) return false;
+	out = *v8::String::Utf8Value(isolate, maybeVal.ToLocalChecked());
+	return true;
 }
 
 bool V8::SafeToFunction(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, v8::Local<v8::Function>& out)
@@ -629,18 +609,16 @@ bool V8::SafeToFunction(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, v8
 
 bool V8::SafeToObject(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, v8::Local<v8::Object>& out)
 {
+	if(!val->IsObject()) return false;
 	v8::MaybeLocal maybeVal = val->ToObject(ctx);
-	if (!maybeVal.IsEmpty())
-	{
-		out = maybeVal.ToLocalChecked();
-		return true;
-	}
-
-	return false;
+	if (maybeVal.IsEmpty()) return false;
+	out = maybeVal.ToLocalChecked();
+	return true;
 }
 
 bool V8::SafeToRGBA(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, alt::RGBA& out)
 {
+	if(!val->IsObject()) return false;
 	v8::MaybeLocal maybeVal = val->ToObject(ctx);
 	if (!maybeVal.IsEmpty())
 	{
@@ -662,6 +640,7 @@ bool V8::SafeToRGBA(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, alt::R
 
 bool V8::SafeToVector3(v8::Local<v8::Value> val, v8::Local<v8::Context> ctx, alt::Vector3f& out)
 {
+	if(!val->IsObject()) return false;
 	v8::MaybeLocal maybeVal = val->ToObject(ctx);
 	if (!maybeVal.IsEmpty())
 	{


### PR DESCRIPTION
This actually checks if the given value is the type needed. Also cleans up the functions a bit with early returns.
As this is a big change that can break a lot of scripts **DO NOT MERGE THIS UNTIL I MARK IT AS READY**.