### PR TITLE
Add support for shared module

### DIFF
--- a/V8Helpers.h
+++ b/V8Helpers.h
@@ -170,8 +170,6 @@ namespace V8
 	v8::Local<v8::Value> Get(v8::Local<v8::Context> ctx, v8::Local<v8::Object> obj, const char *name);
 	v8::Local<v8::Value> Get(v8::Local<v8::Context> ctx, v8::Local<v8::Object> obj, v8::Local<v8::Name> name);
 
-	void RegisterSharedMain(v8::Local<v8::Context> ctx, v8::Local<v8::Object> exports);
-
 	v8::Local<v8::Value> New(v8::Isolate *isolate, v8::Local<v8::Context> ctx, v8::Local<v8::Function> constructor, std::vector<v8::Local<v8::Value>> &args);
 
 	// TODO: create c++ classes for v8 classes and move there

--- a/V8Module.h
+++ b/V8Module.h
@@ -40,12 +40,14 @@ public:
     std::string moduleName;
     std::unordered_set<V8Class *> classes;
     Callback creator;
+    V8Module* parentModule;
 
     template <class... cc>
     V8Module(
         std::string moduleName,
+        V8Module* parent,
         std::initializer_list<std::reference_wrapper<V8Class>> _classes,
-        Callback fn) : moduleName(moduleName), creator(fn)
+        Callback fn) : moduleName(moduleName), creator(fn), parentModule(parent)
     {
         for (auto &c : _classes)
             classes.insert(&c.get());
@@ -55,6 +57,7 @@ public:
 
     void Register(v8::Isolate *isolate, v8::Local<v8::Context> context, v8::Local<v8::Object> exports)
     {
+        if(parentModule) parentModule->Register(isolate, context, exports);
         // Load all classes
         for (auto c : classes)
         {

--- a/bindings/Main.cpp
+++ b/bindings/Main.cpp
@@ -397,4 +397,13 @@ extern V8Module v8Shared("alt-shared", nullptr,
 	V8_OBJECT_SET_BOOLEAN(exports, "debug", alt::ICore::Instance().IsDebug());
 
 	V8_OBJECT_SET_STRING(exports, "resourceName", V8ResourceImpl::GetResource(ctx)->GetName());
+
+#ifdef ALT_CLIENT_API
+	V8_OBJECT_SET_BOOLEAN(exports, "isClient", true);
+	V8_OBJECT_SET_BOOLEAN(exports, "isServer", false);
+#endif
+#ifdef ALT_SERVER_API
+	V8_OBJECT_SET_BOOLEAN(exports, "isClient", false);
+	V8_OBJECT_SET_BOOLEAN(exports, "isServer", true);
+#endif
 });

--- a/bindings/Main.cpp
+++ b/bindings/Main.cpp
@@ -1,6 +1,7 @@
 
 #include "../V8Helpers.h"
 #include "../V8ResourceImpl.h"
+#include "../V8Module.h"
 
 static void HashCb(const v8::FunctionCallbackInfo<v8::Value> &info)
 {
@@ -335,8 +336,25 @@ static void GetRemoteEventListeners(const v8::FunctionCallbackInfo<v8::Value>& i
 	V8_RETURN(array);
 }
 
-void V8::RegisterSharedMain(v8::Local<v8::Context> ctx, v8::Local<v8::Object> exports)
+extern V8Class v8BaseObject,
+	v8WorldObject,
+	v8Entity,
+	v8File,
+	v8RGBA,
+	v8Vector2,
+	v8Vector3;
+
+extern V8Module v8Shared("alt-shared", nullptr,
 {
+	v8BaseObject,
+	v8WorldObject,
+	v8Entity,
+	v8File,
+	v8RGBA,
+	v8Vector2,
+	v8Vector3
+},
+[](v8::Local<v8::Context> ctx, v8::Local<v8::Object> exports) {
 	v8::Isolate *isolate = ctx->GetIsolate();
 
 	V8Helpers::RegisterFunc(exports, "hash", &HashCb);
@@ -373,12 +391,10 @@ void V8::RegisterSharedMain(v8::Local<v8::Context> ctx, v8::Local<v8::Object> ex
 
 	V8Helpers::RegisterFunc(exports, "hasResource", &HasResource);
 
-	V8::DefineOwnProperty(isolate, ctx, exports, "version", v8::String::NewFromUtf8(isolate, alt::ICore::Instance().GetVersion().CStr()).ToLocalChecked());
-	V8::DefineOwnProperty(isolate, ctx, exports, "branch", v8::String::NewFromUtf8(isolate, alt::ICore::Instance().GetBranch().CStr()).ToLocalChecked());
+	V8_OBJECT_SET_STRING(exports, "version", alt::ICore::Instance().GetVersion());
+	V8_OBJECT_SET_STRING(exports, "branch", alt::ICore::Instance().GetBranch());
+	V8_OBJECT_SET_INT(exports, "sdkVersion", alt::ICore::Instance().SDK_VERSION);
+	V8_OBJECT_SET_BOOLEAN(exports, "debug", alt::ICore::Instance().IsDebug());
 
-	V8::DefineOwnProperty(isolate, ctx, exports, "resourceName", v8::String::NewFromUtf8(isolate, V8ResourceImpl::GetResource(ctx)->GetName().CStr()).ToLocalChecked());
-
-	V8::DefineOwnProperty(isolate, ctx, exports, "sdkVersion", v8::Integer::New(isolate, alt::ICore::Instance().SDK_VERSION));
-
-	V8::DefineOwnProperty(isolate, ctx, exports, "debug", v8::Boolean::New(isolate, alt::ICore::Instance().IsDebug()));
-}
+	V8_OBJECT_SET_STRING(exports, "resourceName", V8ResourceImpl::GetResource(ctx)->GetName());
+});


### PR DESCRIPTION
Registers the shared classes, functions & properties as it's own `V8Module` instead of registering these in the modules that use the helpers. Also adds support for `V8Module`'s to have a parent module, from which everything will be inherited.